### PR TITLE
Remove Extra Nodes from customizations.xml

### DIFF
--- a/src/customizations.xml
+++ b/src/customizations.xml
@@ -20,32 +20,6 @@
       <FileName>/Controls/CC.LifeStage/ControlManifest.xml</FileName>
     </CustomControl>
 
-    <CustomControl>
-      <Name>JS_AngularJSFlipControl</Name>
-      <FileName>/Controls/JS_AngularJSFlipControl/ControlManifest.xml</FileName>
-    </CustomControl>
-    <CustomControl>
-      <Name>JS_HelloWorldControl</Name>
-      <FileName>/Controls/JS_HelloWorldControl/ControlManifest.xml</FileName>
-    </CustomControl>
-
-    <CustomControl>
-      <Name>NotificationTile</Name>
-      <FileName>/Controls/NotificationTile/ControlManifest.xml</FileName>
-    </CustomControl>
-    <CustomControl>
-      <Name>PeopleTiles</Name>
-      <FileName>/Controls/PeopleTiles/ControlManifest.xml</FileName>
-    </CustomControl>
-	<CustomControl>
-      <Name>ProductTiles</Name>
-      <FileName>/Controls/ProductTiles/ControlManifest.xml</FileName>
-    </CustomControl>
-    <CustomControl>
-      <Name>RelationshipTile</Name>
-      <FileName>/Controls/RelationshipTile/ControlManifest.xml</FileName>
-    </CustomControl>
-
   </CustomControls>
   <Languages>
     <Language>1033</Language>


### PR DESCRIPTION
Remove <CustomControl/> items that do not exist for this solution. Building solution.zip with these items would result in a solution.zip file that cannot be successfully imported. It would generate a missing root component error.